### PR TITLE
“src-sw.js”

### DIFF
--- a/Develop/client/src-sw.js
+++ b/Develop/client/src-sw.js
@@ -1,11 +1,11 @@
-const { offlineFallback, warmStrategyCache } = require('workbox-recipes');
-const { CacheFirst } = require('workbox-strategies');
+const { offlineFallback, warmStrategyCache } = require('workbox-recipes'); 
+const { CacheFirst, StaleWhileRevalidate } = require('workbox-strategies');
 const { registerRoute } = require('workbox-routing');
 const { CacheableResponsePlugin } = require('workbox-cacheable-response');
 const { ExpirationPlugin } = require('workbox-expiration');
 const { precacheAndRoute } = require('workbox-precaching/precacheAndRoute');
 
-precacheAndRoute(self.__WB_MANIFEST);
+precacheAndRoute(self.__WB_MANIFEST); 
 
 const pageCache = new CacheFirst({
   cacheName: 'page-cache',
@@ -14,7 +14,7 @@ const pageCache = new CacheFirst({
       statuses: [0, 200],
     }),
     new ExpirationPlugin({
-      maxAgeSeconds: 30 * 24 * 60 * 60,
+      maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
     }),
   ],
 });
@@ -27,4 +27,20 @@ warmStrategyCache({
 registerRoute(({ request }) => request.mode === 'navigate', pageCache);
 
 // TODO: Implement asset caching
-registerRoute();
+// Asset Caching: Cache CSS, JS, and Images
+registerRoute(
+  ({ request }) => request.destination === 'style' || request.destination === 'script' || request.destination === 'image',
+  new StaleWhileRevalidate({
+    cacheName: 'asset-cache',
+    plugins: [
+      new CacheableResponsePlugin({
+        statuses: [0, 200],
+      }),
+      new ExpirationPlugin({
+        maxEntries: 60, // Limit number of files
+        maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
+      }),
+    ],
+  })
+);
+


### PR DESCRIPTION

Asset Caching Strategy: The StaleWhileRevalidate strategy is used for caching assets like CSS, JavaScript, and images. This strategy serves the cached version of the file and updates the cache in the background if there's an update available.

Cacheable Response Plugin: Ensures that only requests with certain response statuses (like 200 OK) are cached.

Expiration Plugin: This plugin limits the number of entries in the cache and the amount of time items can stay in the cache. It helps prevent the cache from growing indefinitely.

Register Route for Assets: The registerRoute function is used to apply the caching strategy to requests based on their type (style, script, image).

