### PR TITLE
“webpack.config.js”

### DIFF
--- a/Develop/client/webpack.config.js
+++ b/Develop/client/webpack.config.js
@@ -18,12 +18,45 @@ module.exports = () => {
       path: path.resolve(__dirname, 'dist'),
     },
     plugins: [
-      
+      new HtmlWebpackPlugin({
+        template: './index.html', 
+        filename: 'index.html'
+      }),
+      new WebpackPwaManifest({
+        name: 'Your App Name',
+        short_name: 'AppShortName',
+        description: 'Your application description',
+        background_color: '#ffffff',
+        crossorigin: 'use-credentials', // Can be set to 'anonymous'
+        icons: [
+          {
+            src: path.resolve('src/images/logo.png'), 
+            sizes: [96, 128, 192, 256, 384, 512] // Multiple sizes
+          }
+        ]
+      }),
+      new InjectManifest({
+        swSrc: './src-sw.js', 
+        swDest: 'service-worker.js'
+      })
     ],
-
     module: {
       rules: [
-        
+        {
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader']
+        },
+        {
+          test: /\.m?js$/,
+          exclude: /node_modules/,
+          use: {
+            loader: 'babel-loader',
+            options: {
+              presets: ['@babel/preset-env'],
+              plugins: ['@babel/plugin-transform-runtime']
+            }
+          }
+        }
       ],
     },
   };


### PR DESCRIPTION
// TODO: Add and configure workbox plugins for a service worker and manifest file.
// TODO: Add CSS loaders and babel to webpack.

Explanation of the Configuration:
- Entry Points: Defines the entry points of the application (main and install scripts).
- Output: Specifies the output file names and output directory.
- HtmlWebpackPlugin: Automatically injects the bundled files into your index.html.
- WebpackPwaManifest: Generates a manifest.json for your PWA with specified properties like name, icons, and background color.
- InjectManifest: Integrates the custom service worker with Workbox.
- CSS Loaders: The style-loader and css-loader are used to process CSS files. The style-loader injects CSS into the DOM, and css-loader interprets @import and url() like import/require() and resolves them.
- Babel Loader: Transpiles ES6+ JavaScript to backwards compatible JavaScript that can run in older browsers. It's configured to use @babel/preset-env for presetting and @babel/plugin-transform-runtime for optimizing code.